### PR TITLE
remove commented code

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,5 @@ fi
 
 tokenValue=$(echo $output | jq -cs | jq -r '.[0].token')
 
-#echo "::set-output name=token::$tokenValue"
 echo "token=$tokenValue" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Removed commented code, because it produces a warning now:

"The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/"