### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
Potential fix for [https://github.com/qbee-io/authenticate-action/security/code-scanning/1](https://github.com/qbee-io/authenticate-action/security/code-scanning/1)

To fix this issue, explicitly set the `permissions` block to limit the GITHUB_TOKEN to the minimum set of privileges needed. For the provided workflow, only read access to repository contents appears necessary: code checkout (via actions/checkout) requires `contents: read` (which is the minimal access).  
**How to fix:**  
- Add a `permissions: contents: read` block at the job-level (directly under the `build:` job in the YAML), or at the workflow root if it should apply to all jobs.  
**Details:**  
- Insert the following lines after the job name (`build:`) but before `runs-on: ...` inside the `.github/workflows/main.yml` file:  
  ```yaml
  permissions:
    contents: read
  ```
- This change ensures that the GITHUB_TOKEN used by this job has only the minimal read permissions needed, following the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
